### PR TITLE
Update basic.php

### DIFF
--- a/examples/basic.php
+++ b/examples/basic.php
@@ -1,7 +1,8 @@
 <?php
-session_start();
 
 include '../vendor/autoload.php';
+
+session_start();
 
 use Paxx\Withings\Provider\Withings as WithingsAuth;
 use Paxx\Withings\Api as WithingsApi;


### PR DESCRIPTION
Move session_start() to after including the autoloader so that the classes exist when retrieving the token from the session variable.
