### PR TITLE
Update Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         "guzzle/guzzle": "~3.3"
     },
     "autoload": {
-        "psr-0": {
-            "Paxx\\Withings": "src/"
+        "psr-4": {
+            "Paxx\\Withings\\": "src/Paxx/Withings"
         }
     },
     "minimum-stability": "dev"


### PR DESCRIPTION
Update composer to use the ~ ("within current release") selector to allow this to work on sites using Laravel/Illuminate 4.2.
Update Composer to allow for `3.3` _and up_ so `oauth1`'s `3.3.*` dependency doesn't conflict.
