### PR TITLE
Remove socialite requirement and suggest socialiteproviders/withings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,10 @@
         "league/oauth1-client": "~1.0",
         "illuminate/support": "~5.0",
         "guzzlehttp/guzzle": "~6.0",
-        "guzzlehttp/oauth-subscriber": "~0.3",
-        "laravel/socialite": "^2.0"
+        "guzzlehttp/oauth-subscriber": "~0.3"
+    },
+    "suggest": {
+        "socialiteproviders/withings": "Integrates nicely with SocialiteProviders for Laravel"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
After my test yesterday (#25), I wrote a [socialiteproviders](https://socialiteproviders.github.io/)' provider based on your code : https://github.com/Alex131089/socialiteproviders-withings.
So after following the SocialiteProviders installation instructions, you can use somethings like:
```php
use Socialite;
use Paxx\Withings\Api as WithingsApi;

Route::get('withings', function() {
    return Socialite::driver('withings')->redirect();
});
Route::get('withings/callback', function() {
    $user = Socialite::driver('fitbit')->user();
    save_user_credentials($user);
});
Route::get('withings/test', function() {
    $config = [
        'identifier' => env('WITHINGS_KEY'),
        'secret' => env('WITHINGS_SECRET'),
    ] + get_user_credentials();
    $api = new WithingsApi($config);
    $measures = $api->getMeasures();
    dd($measures);
});
```

As Socialite doesn't support extension officialy (if I got it right), maybe this should be suggested instead of socialite ?
I haven't made a pull request on the https://github.com/SocialiteProviders/Providers repo yet: while it is mentioned the code is mostly (Servers's User field a bit modified) from `Paxx\Withings` (and is a suggestion), should your name be added somewhere ?